### PR TITLE
develop-feat: Add dynamic entries count display to PageAuth

### DIFF
--- a/database.types.ts
+++ b/database.types.ts
@@ -26,7 +26,7 @@ export type Database = {
           name: string
           order?: number
           paid?: boolean
-          user_id?: string
+          user_id: string
         }
         Update: {
           amount?: number
@@ -36,6 +36,27 @@ export type Database = {
           order?: number
           paid?: boolean
           user_id?: string
+        }
+        Relationships: []
+      }
+      stats: {
+        Row: {
+          created_at: string
+          id: number
+          name: string
+          value: number
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          name: string
+          value: number
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          name?: string
+          value?: number
         }
         Relationships: []
       }

--- a/src/pages/PageAuth.vue
+++ b/src/pages/PageAuth.vue
@@ -4,6 +4,12 @@
       <q-card-section>
         <ToolbarTitle />
       </q-card-section>
+      <q-card-section class="q-pb-none">
+        <q-banner :class="{ 'fade-in': entriesCount }" class="banner bg-primary text-white text-center text-italic ">
+          <div>Over {{entriesCount}} Entries have been</div>
+          <div>created with Budget App</div>
+        </q-banner>
+      </q-card-section>
       <q-card-section>
         <q-tabs v-model="tab" no-caps>
           <q-tab name="login" label="Login" />
@@ -46,12 +52,36 @@
 
 <script setup lang="ts">
 import ToolbarTitle from 'components/Layout/ToolbarTitle.vue';
-import { ref, computed, reactive } from 'vue';
+import { ref, computed, reactive, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 import { useAuthStore } from 'stores/auth-store';
+import supabase from 'src/config/supabase';
+import {useShowErrorMessage} from 'src/use/useShowErrorMessage';
 
 // Stores
 const authStore = useAuthStore();
+const showErrorMessage = useShowErrorMessage();
+// refs
+const entriesCount = ref(0);
+
+// life cycle
+
+onMounted(async () => {
+  const { data, error } = await supabase
+    .from('stats')
+    .select("*")
+
+    // Filters
+    .eq('name', 'entries_count')
+
+  if (error) {
+    showErrorMessage(error.message, "getStats")
+    return
+  }
+  if(data) {
+    entriesCount.value = data[0]!.value
+  }
+})
 
 // UI
 const tab = ref('login');
@@ -92,5 +122,15 @@ const handleSubmit = async () => {
 <style scoped>
 .card {
   min-width: 300px;
+}
+.banner {
+  border: 1px solid #fff;
+  border-radius: 60px;
+  opacity: 0;
+}
+.fade-in {
+  animation: fadeIn 2s;
+  animation-fill-mode: forwards;
+  opacity: 1;
 }
 </style>

--- a/src/stores/entries-store.ts
+++ b/src/stores/entries-store.ts
@@ -71,6 +71,21 @@ export const useEntriesStore = defineStore('entries', () => {
     actions
   */
 
+  // const updateEntriesCount = async () => {
+  //   const { error } = await supabase.rpc('increment_entries')
+  //
+  //   if(error) {
+  //     showErrorMessage(error.message, "updateEntriesCount")
+  //     return
+  //   }
+  //
+  //   Notify.create({
+  //     message: 'Entries count successfully updated',
+  //     position: 'top',
+  //     color: 'positive'
+  //   })
+  // }
+
   const addEntry = async (addEntryForm: AddEntryForm) => {
     if(!authStore.getUserId()) {
       showErrorMessage(USER_MUST_LOG_IN_MESSAGE, "addEntry")


### PR DESCRIPTION
Introduced a banner in the authentication page to display the total number of entries created in the app, fetched dynamically from the database. Refactored database schema to include a `stats` table for managing entry count and added the required logic for data retrieval and error handling. Enhanced styles to include a fade-in animation for the banner.